### PR TITLE
Rename WayPoint to Waypoint

### DIFF
--- a/Game/CommandPacket.h
+++ b/Game/CommandPacket.h
@@ -5,7 +5,7 @@
 #define CommandPacket_H
 
 
-#include "WayPoint.h"
+#include "Waypoint.h"
 
 
 namespace OP2Internal
@@ -45,10 +45,10 @@ namespace OP2Internal
 			short unitIndex[1];	// List of unit indexes
 		};
 
-		struct WayPointList
+		struct WaypointList
 		{
-			short numWayPoints;
-			WayPoint wayPoint[1];
+			short numWaypoints;
+			Waypoint waypoint[1];
 		};
 		struct ShortPoint
 		{
@@ -80,9 +80,9 @@ namespace OP2Internal
 		struct CargoRoute
 		{
 			//UnitList
-			//WayPointList
-			short smelterWayPointIndex;
-			short mineWayPointIndex;
+			//WaypointList
+			short smelterWaypointIndex;
+			short mineWaypointIndex;
 			short mineUnitIndex;
 			short smelterUnitIndex;
 		};
@@ -90,7 +90,7 @@ namespace OP2Internal
 		struct Patrol
 		{
 			//UnitList
-			//WayPointList
+			//WaypointList
 			short unknown1;		// ** Probably waypoint indexes of end patrol endpoints
 			short unknown2;		// **
 		};
@@ -98,7 +98,7 @@ namespace OP2Internal
 		struct Build
 		{
 			//UnitList
-			//WayPointList
+			//WaypointList
 			ShortRect buildArea;
 			short unknown;		// ** Might be scStubIndex (related to BuildGroup), set to -1 if not used
 		};
@@ -106,7 +106,7 @@ namespace OP2Internal
 		struct BuildWall
 		{
 			//UnitList
-			//WayPointList
+			//WaypointList
 			ShortRect buildArea;
 			short tubeWallType;	// enum map_id
 			short unknown;		// ** Might be scStubIndex (related to BuildGroup), set to 0 if not used

--- a/Game/ScStub/ScStubGroupCombatBase.h
+++ b/Game/ScStub/ScStubGroupCombatBase.h
@@ -6,7 +6,7 @@
 
 
 #include "ScStubGroup.h"
-#include "../WayPoint.h"
+#include "../Waypoint.h"
 #include "../../PointTypes.h"
 
 
@@ -38,7 +38,7 @@ namespace OP2Internal
 		int a1;							// 0x310 ** [Set to 0xFFF00000, related to game tick, possibly spider related]
 		int numWaypoints;				// 0x314
 		int a2;							// 0x318 ** (Set in SetWaypoints to unknown parameter, used in IssuePatrol)
-		WayPoint wayPointList[8];		// 0x31C
+		Waypoint waypointList[8];		// 0x31C
 		int patrolMode;					// 0x33C (Initialized to 0)
 		int followMode;					// 0x340 (Initialized to 0)
 		Rect pixelRect;					// 0x344 (SetRect converted to pixels) (rect.p1.y initialized to -1)

--- a/Game/Unit/Path.h
+++ b/Game/Unit/Path.h
@@ -4,7 +4,7 @@
 #define Path_H
 
 
-#include "../WayPoint.h"
+#include "../Waypoint.h"
 
 
 namespace OP2Internal
@@ -20,7 +20,7 @@ namespace OP2Internal
 		int _08;					// 0x08 **
 		int _0C;					// 0x0C **
 		int _10;					// 0x10 **
-		WayPoint wayPointList[8];	// 0x14
+		Waypoint waypointList[8];	// 0x14
 		int flags;					// 0x34 **
 		Path* next;					// 0x38 **
 		int a0Enum;					// 0x3C ** (0 = Move/Dock/DockEG/StandGround/CargoRoute/Patrol/Build, 3 = RemoveWall)

--- a/Game/Waypoint.h
+++ b/Game/Waypoint.h
@@ -1,12 +1,12 @@
 
 
-#ifndef WayPoint_H
-#define WayPoint_H
+#ifndef Waypoint_H
+#define Waypoint_H
 
 
 namespace OP2Internal
 {
-	struct WayPoint
+	struct Waypoint
 	{
 		unsigned int pixelX:15;
 		unsigned int pixelY:14;

--- a/OP2Internal.vcxproj
+++ b/OP2Internal.vcxproj
@@ -92,7 +92,7 @@
     <ClInclude Include="Game\Unit\UnitBuilding.h" />
     <ClInclude Include="Game\Unit\UnitVehicle.h" />
     <ClInclude Include="Game\Unit\UnitWeapon.h" />
-    <ClInclude Include="Game\WayPoint.h" />
+    <ClInclude Include="Game\Waypoint.h" />
     <ClInclude Include="Network\GurManager.h" />
     <ClInclude Include="Network\NetGameProtocol.h" />
     <ClInclude Include="Network\NetTransportLayer.h" />

--- a/OP2Internal.vcxproj.filters
+++ b/OP2Internal.vcxproj.filters
@@ -339,7 +339,7 @@
     <ClInclude Include="UserInterface\UICommand\MouseCommands\CommandBuild.h">
       <Filter>UserInterface\UICommand\MouseCommands</Filter>
     </ClInclude>
-    <ClInclude Include="Game\WayPoint.h">
+    <ClInclude Include="Game\Waypoint.h">
       <Filter>Game</Filter>
     </ClInclude>
     <ClInclude Include="Game\Unit\Path.h">


### PR DESCRIPTION
I think `Waypoint` should be capitalized as a closed form compound word.
