### PR TITLE
Cleanup enums

### DIFF
--- a/Game/CommandPacket.h
+++ b/Game/CommandPacket.h
@@ -9,6 +9,7 @@
 
 namespace OP2Internal
 {
+	enum class map_id : short;
 
 	#pragma pack(push, 1)
 	struct CommandPacketHeader
@@ -107,7 +108,7 @@ namespace OP2Internal
 			//UnitList
 			//WaypointList
 			ShortRect buildArea;
-			short tubeWallType;	// enum map_id
+			map_id tubeWallType;
 			short unknown;		// ** Might be scStubIndex (related to BuildGroup), set to 0 if not used
 		};
 
@@ -121,8 +122,8 @@ namespace OP2Internal
 		struct Produce
 		{
 			short factoryUnitIndex;		// 0x0E
-			short itemType;				// 0x10 enum map_id
-			short weaponType;			// 0x12 enum map_id
+			map_id itemType;				// 0x10
+			map_id weaponType;			// 0x12
 			short scStubIndex;			// 0x14 -1 if not used
 		};
 
@@ -204,6 +205,7 @@ namespace OP2Internal
 			short tileY;
 			int weaponOrCargo;	// enum map_id
 		};
+		static_assert(12 == sizeof(CreateUnitInfo), "Unexpected struct size");
 		struct Create
 		{
 			short numUnits;

--- a/Game/GameStartInfo/EnumGameTermReasons.h
+++ b/Game/GameStartInfo/EnumGameTermReasons.h
@@ -4,7 +4,7 @@
 namespace OP2Internal
 {
 
-	enum GameTermReasons
+	enum class GameTermReasons
 	{
 		GameTermRunning				= 0,	// Still running
 		

--- a/Game/Research.h
+++ b/Game/Research.h
@@ -9,7 +9,7 @@ namespace OP2Internal
 	struct TechInfo;
 	struct TechUpgradeInfo;
 	struct UpgradeType;
-	enum TechCategory;
+	enum class TechCategory;
 
 
 	class Research
@@ -73,7 +73,7 @@ namespace OP2Internal
 
 
 	// "CATEGORY" values (for both items and upgrades to these items)
-	enum TechCategory
+	enum class TechCategory
 	{
 		tcFree,						// 0 = Free technologies (and unavailable technologies)
 		tcBasic,					// 1 = Basic labratory sciences

--- a/Game/ScStub/ScStubGroup.h
+++ b/Game/ScStub/ScStubGroup.h
@@ -4,7 +4,7 @@
 
 
 enum class UnitClassifactions;
-enum class map_id;
+enum class map_id : short;
 
 
 namespace OP2Internal

--- a/Game/ScStub/ScStubGroup.h
+++ b/Game/ScStub/ScStubGroup.h
@@ -3,8 +3,8 @@
 #include "ScStub.h"
 
 
-enum UnitClassifactions;
-enum map_id;
+enum class UnitClassifactions;
+enum class map_id;
 
 
 namespace OP2Internal

--- a/Game/ScStub/ScStubGroupBuildGroup.h
+++ b/Game/ScStub/ScStubGroupBuildGroup.h
@@ -8,7 +8,7 @@
 #include "../../PointTypes.h"
 
 
-enum class map_id;
+enum class map_id : short;
 
 
 namespace OP2Internal

--- a/Game/ScStub/ScStubGroupBuildGroup.h
+++ b/Game/ScStub/ScStubGroupBuildGroup.h
@@ -8,7 +8,7 @@
 #include "../../PointTypes.h"
 
 
-enum map_id;
+enum class map_id;
 
 
 namespace OP2Internal

--- a/Game/ScStub/ScStubGroupCombatBase.h
+++ b/Game/ScStub/ScStubGroupCombatBase.h
@@ -9,7 +9,7 @@
 #include "../../PointTypes.h"
 
 
-enum class map_id;
+enum class map_id : short;
 
 
 namespace OP2Internal

--- a/Game/ScStub/ScStubGroupCombatBase.h
+++ b/Game/ScStub/ScStubGroupCombatBase.h
@@ -9,7 +9,7 @@
 #include "../../PointTypes.h"
 
 
-enum map_id;
+enum class map_id;
 
 
 namespace OP2Internal

--- a/Game/Sheet.h
+++ b/Game/Sheet.h
@@ -7,7 +7,7 @@
 namespace OP2Internal
 {
 
-	enum class map_id;
+	enum class map_id : short;
 	class Unit;
 
 
@@ -26,7 +26,7 @@ namespace OP2Internal
 	};
 
 
-	enum class map_id {
+	enum class map_id : short {
 		mapAny = -1,					// FF Use to specify 'all' or 'any'
 		mapNone = 0,					// 00
 

--- a/Game/Sheet.h
+++ b/Game/Sheet.h
@@ -7,7 +7,7 @@
 namespace OP2Internal
 {
 
-	enum map_id;
+	enum class map_id;
 	class Unit;
 
 
@@ -26,7 +26,7 @@ namespace OP2Internal
 	};
 
 
-	enum map_id {
+	enum class map_id {
 		mapAny = -1,					// FF Use to specify 'all' or 'any'
 		mapNone = 0,					// 00
 

--- a/Game/TethysGame.h
+++ b/Game/TethysGame.h
@@ -9,7 +9,7 @@
 namespace OP2Internal
 {
 
-	enum GameTermReasons;
+	enum class GameTermReasons;
 	class StreamIO;
 	class TFileDialog;
 	class GameNetLayer;

--- a/Game/Unit/Unit.h
+++ b/Game/Unit/Unit.h
@@ -95,7 +95,7 @@ namespace OP2Internal
 		char command;					// 0x21 
 		char action;					// 0x22 
 		char executingAction;			// 0x23 
-		short cargo;					// 0x24 [enum map_id]
+		map_id cargo;					// 0x24
 		short attackingUnitIndex;		// 0x26 
 		int lastAttackedTick;			// 0x28 (Valid when (gameTick - lastAttackedTick) < 30)
 		short unitTypeInstanceNum;		// 0x2C

--- a/Game/Unit/UnitVehicle.h
+++ b/Game/Unit/UnitVehicle.h
@@ -32,13 +32,16 @@ namespace OP2Internal
 		// ...
 	};
 
+
+	enum class Truck_Cargo;
+
 	class CargoTruck : public Vehicle
 	{
 	public:
 		// ----  [Overridden base class functions]
 		// ... **TODO**
 		// ----  [New virtual functions]
-		virtual void SetCargo(enum Truck_Cargo truckCargo, int cargoAmountOrTechID, short a2);	// 0x94 **
+		virtual void SetCargo(Truck_Cargo truckCargo, int cargoAmountOrTechID, short a2);	// 0x94 **
 		virtual void F9();							// 0x98 **
 		// ----
 	};

--- a/Game/UnitTypeInfo/UnitTypeInfo.h
+++ b/Game/UnitTypeInfo/UnitTypeInfo.h
@@ -6,7 +6,7 @@ namespace OP2Internal
 
 	class Unit;
 	class StreamIO;
-	enum map_id;
+	enum class map_id : short;
 
 
 	enum BuildingAnimationTypeIndex
@@ -97,7 +97,7 @@ namespace OP2Internal
 		// Member variables
 		// ----
 		// vtbl								// 0x0
-		map_id unitType;					// 0x4
+		map_id unitType;					// 0x4  (Note: This field is padded to 4 bytes for alignment of next field)
 		PlayerUnitInfo playerInfo[7];		// 0x8
 		int requiredTechIndex;				// 0x1E4
 		int trackType;						// 0x1E8

--- a/ResourceManagement/MusicManager.h
+++ b/ResourceManagement/MusicManager.h
@@ -10,7 +10,7 @@ struct DirectSoundBuffer;
 namespace OP2Internal
 {
 
-	enum SongIds;
+	enum class SongIds;
 
 
 	class MusicManager

--- a/UserInterface/Filter/FilterNode.h
+++ b/UserInterface/Filter/FilterNode.h
@@ -6,13 +6,13 @@ namespace OP2Internal
 
 	class Filter;
 
-	enum FilterPositions
+	enum class FilterPositions
 	{
 		FilterPosLast = 0,
 		FilterPosFirst = 1,
 	};
 
-	enum FilterOptions
+	enum class FilterOptions
 	{
 		FilterOptMouseMessage = 1,
 		FilterOptKeyboardMessage = 2,

--- a/UserInterface/Filter/FilterSubFilterMouseCommandFilter.h
+++ b/UserInterface/Filter/FilterSubFilterMouseCommandFilter.h
@@ -10,7 +10,7 @@ namespace OP2Internal
 
 	class BoolState;
 	class Pane;
-	enum BehaviorType;
+	enum class BehaviorType;
 
 
 	class MouseCommandFilter : public SubFilter
@@ -64,7 +64,7 @@ namespace OP2Internal
 	};
 
 
-	enum BehaviorType
+	enum class BehaviorType
 	{
 		BandboxUnitSelect = 0,		// Left-clicking starts drawing a bandbox
 		SetRectRegion = 1,			// Bulldoze or Salvage region

--- a/UserInterface/IWnd/IWnd.h
+++ b/UserInterface/IWnd/IWnd.h
@@ -8,6 +8,8 @@ namespace OP2Internal
 {
 
 	class FilterNode;
+	enum class FilterPositions;
+	enum class FilterOptions;
 
 
 	// Size: 0x14
@@ -28,7 +30,7 @@ namespace OP2Internal
 		IWnd();
 		class IWnd & operator=(class IWnd const &);
 		class FilterNode * FindNode(class Filter *,int);
-		void InstallFilter(class Filter*, int userData, enum FilterPositions, enum FilterOptions);
+		void InstallFilter(class Filter*, int userData, FilterPositions filterPosition, FilterOptions filterOption);
 		void RemoveFilter(class Filter*, int userData);
 
 		// Static functions


### PR DESCRIPTION
This cleans up errors flagged by Mingw.

MSVC supported a C++ extension to allow forward declaring of enums. This was not standard C++, which didn't support forwarding of enums until C++11, with the introduction of both enum base types and enum classes (which have an implicit base type, if not explicitly stated).

By switching to `enum class`, this makes the forward declarations compliant with C++ standard rules.

Related, we should add static size checks for many structs and classes. In particular, the `map_id` enum is used in inconsistent ways, sometimes stored in 32-bit fields, sometimes stored in 16-bit fields. Attention will need to be paid to this. I've done a bit of manual verification here, but I'm pushing compiler automated verification off as work for a separate branch.
