### PR TITLE
Add macro to help size check structs and classes

### DIFF
--- a/AssertSize.h
+++ b/AssertSize.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define AssertSize(Size, Struct) \
+	static_assert((Size) == sizeof(Struct), "Expected sizeof(" #Struct ") == " #Size)

--- a/Game/CommandPacket.h
+++ b/Game/CommandPacket.h
@@ -5,6 +5,7 @@
 
 
 #include "Waypoint.h"
+#include "../AssertSize.h"
 
 
 namespace OP2Internal
@@ -125,6 +126,7 @@ namespace OP2Internal
 			short weaponType;			// 0x12 enum map_id
 			short scStubIndex;			// 0x14 -1 if not used
 		};
+		AssertSize(8, Produce);
 
 		struct TransferCargo
 		{
@@ -204,6 +206,7 @@ namespace OP2Internal
 			short tileY;
 			int weaponOrCargo;	// enum map_id
 		};
+		AssertSize(12, CreateUnitInfo);
 		struct Create
 		{
 			short numUnits;


### PR DESCRIPTION
This shortens the typing, while providing a standard error message with details specific to the class.

I included a couple of example uses. This pull request does not size check everything that needs to be checked. This is more to settle on a helper macro to accomplish that.
