### PR TITLE
Change parameters from pointer to ref

### DIFF
--- a/Network/NetTransportLayer.h
+++ b/Network/NetTransportLayer.h
@@ -31,14 +31,14 @@ namespace OP2Internal
 		virtual int ReplicatePlayersList() = 0;
 		virtual int GetOpponentNetIDList(int netIDList[], int maxNumID) = 0;
 		virtual void RemovePlayer(int playerNetID) = 0;
-		virtual int Send(Packet* packet) = 0;
-		virtual int Receive(Packet* packet) = 0;
+		virtual int Send(Packet& packet) = 0;
+		virtual int Receive(Packet& packet) = 0;
 		virtual int IsHost() = 0;
 		virtual int IsValidPlayer() = 0;
 		virtual int F1() = 0;						// ** Return 1
 		virtual int GetAddressString(int playerNetID, char* addressString, int bufferSize) = 0;
 		virtual int ResetTrafficCounters() = 0;
-		virtual int GetTrafficCounts(TrafficCounters* trafficCounters) = 0;
+		virtual int GetTrafficCounts(TrafficCounters& trafficCounters) = 0;
 	};
 
 

--- a/OP2Internal.asm
+++ b/OP2Internal.asm
@@ -131,7 +131,7 @@ ExportVirt 0x00460BC0, ?DlgProc@MultiplayerPreGameSetupWnd@OP2Internal@@UAEHIIJ@
 ; Constructor/Destructor
 Export 0x0045F050, ??0MultiplayerPreGameSetupWnd@OP2Internal@@QAE@XZ
 ; Member functions
-Export 0x0045F0D0, ?ShowHostGame@MultiplayerPreGameSetupWnd@OP2Internal@@QAE_NPAUHostGameParameters@2@@Z
+Export 0x0045F0D0, ?ShowHostGame@MultiplayerPreGameSetupWnd@OP2Internal@@QAE_NAAUHostGameParameters@2@@Z
 Export 0x0045F2F0, ?ShowJoinGame@MultiplayerPreGameSetupWnd@OP2Internal@@QAE_NPADH_N@Z
 
 

--- a/UserInterface/IWnd/IWndIDlgWndMultiplayerPreGameSetupWnd.h
+++ b/UserInterface/IWnd/IWndIDlgWndMultiplayerPreGameSetupWnd.h
@@ -37,7 +37,7 @@ namespace OP2Internal
 
 		// Non virtual member functions
 		MultiplayerPreGameSetupWnd();															// 0x0045F050
-		bool ShowHostGame(HostGameParameters* hostGameParameters);								// 0x0045F0D0
+		bool ShowHostGame(HostGameParameters& hostGameParameters);								// 0x0045F0D0
 		bool ShowJoinGame(char* playerName, int hostPlayerNetID, bool bPurgedDroppedPlayers);	// 0x0045F2F0
 
 	public:

--- a/UserInterface/IWnd/IWndIDlgWndMultiplayerPreGameSetupWnd.h
+++ b/UserInterface/IWnd/IWndIDlgWndMultiplayerPreGameSetupWnd.h
@@ -38,7 +38,7 @@ namespace OP2Internal
 		// Non virtual member functions
 		MultiplayerPreGameSetupWnd();															// 0x0045F050
 		bool ShowHostGame(HostGameParameters& hostGameParameters);								// 0x0045F0D0
-		bool ShowJoinGame(char* playerName, int hostPlayerNetID, bool bPurgedDroppedPlayers);	// 0x0045F2F0
+		bool ShowJoinGame(char* playerName, int hostPlayerNetID, bool bPurgeDroppedPlayers);	// 0x0045F2F0
 
 	public:
 		// Member variables

--- a/UserInterface/IWnd/IWndPane.h
+++ b/UserInterface/IWnd/IWndPane.h
@@ -31,13 +31,13 @@ namespace OP2Internal
 		virtual void ReallocSurface(int zoom);
 		virtual void Draw();
 		virtual void F1();							// **
-		virtual bool GetAbsolutePos(int pixelX, int pixelY, Point* absolutePos);
+		virtual bool GetAbsolutePos(int pixelX, int pixelY, Point& absolutePos);
 
 		// Member functions
-		void AddControl(UIElement* control);
-		void RemoveControl(UIElement* control);
+		void AddControl(UIElement& control);
+		void RemoveControl(UIElement& control);
 		void SetNumControls(int newNumControls);
-		UIElement* GetControlFromPos(int pixelX, int pixelY);
+		UIElement& GetControlFromPos(int pixelX, int pixelY);
 
 
 	public:

--- a/UserInterface/IWnd/IWndPaneCommand.h
+++ b/UserInterface/IWnd/IWndPaneCommand.h
@@ -33,11 +33,15 @@ namespace OP2Internal
 		// virtual bool GetAbsolutePos(int pixelX, int pixelY, Point& absolutePos);
 
 		// [Pane] Virtual member functions
+		// Mark entire surface for redraw with: drawRect = nullptr
 		virtual void MarkRectToRedraw(Rect* drawRect);
+		// No operation if drawRect == nullptr
 		virtual void DrawBackBuffer(Rect* drawRect);
 
 		// Member functions
+		// Set control == nullptr to unselect current control
 		void SetSelectedControl(UIElement* control);
+		// Set newView == nullptr to unselect current view
 		void SetNewView(CommandPaneView* newView);
 		void DrawControlsAndUpdateScreen();
 		int  GetReportButtonHeight();

--- a/UserInterface/IWnd/IWndPaneCommand.h
+++ b/UserInterface/IWnd/IWndPaneCommand.h
@@ -30,7 +30,7 @@ namespace OP2Internal
 		virtual void ReallocSurface(int zoom);
 		virtual void Draw();
 		// virtual void F1();
-		// virtual bool GetAbsolutePos(int pixelX, int pixelY, Point* absolutePos);
+		// virtual bool GetAbsolutePos(int pixelX, int pixelY, Point& absolutePos);
 
 		// [Pane] Virtual member functions
 		virtual void MarkRectToRedraw(Rect* drawRect);

--- a/UserInterface/IWnd/IWndPaneDetail.h
+++ b/UserInterface/IWnd/IWndPaneDetail.h
@@ -28,11 +28,11 @@ namespace OP2Internal
 		virtual bool GetAbsolutePos(int pixelX, int pixelY, Point& absolutePos);
 
 		// [New] Virtual member functions
-		virtual void GetViewportRelativePos(int pixelX, int pixelY, Point* relPos);
-		virtual void GetViewportTilePositionAndSize(Point* topLeftTilePos, Point* tileSize);
+		virtual void GetViewportRelativePos(int pixelX, int pixelY, Point& relPos);
+		virtual void GetViewportTilePositionAndSize(Point& topLeftTilePos, Point& tileSize);
 
 		// Member functions
-		void GetViewCenter(Point* viewCenter);
+		void GetViewCenter(Point& viewCenter);
 
 
 	public:

--- a/UserInterface/IWnd/IWndPaneDetail.h
+++ b/UserInterface/IWnd/IWndPaneDetail.h
@@ -25,7 +25,7 @@ namespace OP2Internal
 		virtual void ReallocSurface(int zoom);
 		virtual void Draw();
 		// virtual void F1();
-		virtual bool GetAbsolutePos(int pixelX, int pixelY, Point* absolutePos);
+		virtual bool GetAbsolutePos(int pixelX, int pixelY, Point& absolutePos);
 
 		// [New] Virtual member functions
 		virtual void GetViewportRelativePos(int pixelX, int pixelY, Point* relPos);

--- a/UserInterface/IWnd/IWndPaneDetail.h
+++ b/UserInterface/IWnd/IWndPaneDetail.h
@@ -28,8 +28,8 @@ namespace OP2Internal
 		virtual bool GetAbsolutePos(int pixelX, int pixelY, Point& absolutePos);
 
 		// [New] Virtual member functions
-		virtual void GetViewportRelativePos(int pixelX, int pixelY, Point& relPos);
-		virtual void GetViewportTilePositionAndSize(Point& topLeftTilePos, Point& tileSize);
+		virtual void GetViewportRelativePosition(int pixelX, int pixelY, Point& relPosInPixels);
+		virtual void GetViewportPositionInTiles(Point& topLeftTile, Point& bottomRightTile);
 
 		// Member functions
 		void GetViewCenter(Point& viewCenter);

--- a/UserInterface/IWnd/IWndPaneMiniMap.h
+++ b/UserInterface/IWnd/IWndPaneMiniMap.h
@@ -31,7 +31,7 @@ namespace OP2Internal
 		virtual void ReallocSurface(int zoom);
 		virtual void Draw();
 		virtual void F1();											// **
-		virtual bool GetAbsolutePos(int pixelX, int pixelY, Point* absolutePos);
+		virtual bool GetAbsolutePos(int pixelX, int pixelY, Point& absolutePos);
 
 		// [New] Virtual member functions
 		virtual void ButtonClick(MiniMapButton* miniMapButton);

--- a/UserInterface/IWnd/IWndPaneMiniMap.h
+++ b/UserInterface/IWnd/IWndPaneMiniMap.h
@@ -34,7 +34,7 @@ namespace OP2Internal
 		virtual bool GetAbsolutePos(int pixelX, int pixelY, Point& absolutePos);
 
 		// [New] Virtual member functions
-		virtual void ButtonClick(MiniMapButton* miniMapButton);
+		virtual void ButtonClick(MiniMapButton& miniMapButton);
 		virtual int  F2(int a1, int a2, int a3);					// **
 
 		// Non virtual member functions

--- a/UserInterface/IWnd/IWndTFrame.h
+++ b/UserInterface/IWnd/IWndTFrame.h
@@ -32,8 +32,8 @@ namespace OP2Internal
 	public:
 		virtual ~TFrame();		// [Overridden]
 		// Note: Insert 5 virtual members here
-		virtual void TFrame_F1(UIState*) = 0;
-		virtual void TFrame_F2(unsigned int controlId) = 0;
+		virtual void GetUIState(UIState* uiState) = 0;
+		virtual void DoCommand(unsigned int controlId) = 0;
 		virtual void TranslateAccelerators(MSG* msg) = 0;
 		virtual void Init() = 0;
 		virtual void Initialize() = 0;

--- a/UserInterface/IWnd/IWndTFrame.h
+++ b/UserInterface/IWnd/IWndTFrame.h
@@ -31,13 +31,12 @@ namespace OP2Internal
 		void HandleMenuInit(HMENU, unsigned int,int);
 	public:
 		virtual ~TFrame();		// [Overridden]
-		// Note: Insert 5 virtual members here
+
 		virtual void GetUIState(UIState& uiState) = 0;
 		virtual void DoCommand(unsigned int controlId) = 0;
 		virtual void TranslateAccelerators(MSG* msg) = 0;
 		virtual void Init() = 0;
 		virtual void Initialize() = 0;
-		// Note: End extra 5 virtual members
 		virtual void Activate();
 		virtual void Deactivate();
 		virtual void OnIdle();

--- a/UserInterface/IWnd/IWndTFrame.h
+++ b/UserInterface/IWnd/IWndTFrame.h
@@ -32,7 +32,7 @@ namespace OP2Internal
 	public:
 		virtual ~TFrame();		// [Overridden]
 		// Note: Insert 5 virtual members here
-		virtual void GetUIState(UIState* uiState) = 0;
+		virtual void GetUIState(UIState& uiState) = 0;
 		virtual void DoCommand(unsigned int controlId) = 0;
 		virtual void TranslateAccelerators(MSG* msg) = 0;
 		virtual void Init() = 0;

--- a/UserInterface/IWnd/IWndTFrameDans_RULE_UIFrame.h
+++ b/UserInterface/IWnd/IWndTFrameDans_RULE_UIFrame.h
@@ -48,7 +48,7 @@ namespace OP2Internal
 		// ---------------------------------
 		virtual void ShutDown();
 		// Note: Insert 5 virtual members here
-		virtual void GetUIState(UIState* uiState);
+		virtual void GetUIState(UIState& uiState);
 		virtual void DoCommand(unsigned int controlId);
 		virtual void TranslateAccelerators(MSG* msg);
 		virtual void Init();

--- a/UserInterface/IWnd/IWndTFrameDans_RULE_UIFrame.h
+++ b/UserInterface/IWnd/IWndTFrameDans_RULE_UIFrame.h
@@ -48,8 +48,8 @@ namespace OP2Internal
 		// ---------------------------------
 		virtual void ShutDown();
 		// Note: Insert 5 virtual members here
-		virtual void TFrame_F1(UIState*);
-		virtual void TFrame_F2(unsigned int controlId);
+		virtual void GetUIState(UIState* uiState);
+		virtual void DoCommand(unsigned int controlId);
 		virtual void TranslateAccelerators(MSG* msg);
 		virtual void Init();
 		virtual void Initialize();

--- a/UserInterface/IWnd/IWndTFrameDans_RULE_UIFrame.h
+++ b/UserInterface/IWnd/IWndTFrameDans_RULE_UIFrame.h
@@ -47,13 +47,12 @@ namespace OP2Internal
 		// Virtual member functions (TFrame)
 		// ---------------------------------
 		virtual void ShutDown();
-		// Note: Insert 5 virtual members here
+
 		virtual void GetUIState(UIState& uiState);
 		virtual void DoCommand(unsigned int controlId);
 		virtual void TranslateAccelerators(MSG* msg);
 		virtual void Init();
 		virtual void Initialize();
-		// Note: End extra 5 virtual members
 		virtual void Activate();
 		virtual void Deactivate();
 		virtual void OnIdle();


### PR DESCRIPTION
A number of methods take parameters as a pointer. After examining those methods, many of them use the parameters without first doing a null check. This implies those parameters could have been references, which are non-nullable,  or were unchecked pointers (which should probably have been references).

A few fixes and updates to parameter and method names were made along the way.
