### PR TITLE
Add enum includes

### DIFF
--- a/Game/EnumMapId.h
+++ b/Game/EnumMapId.h
@@ -93,7 +93,7 @@ namespace OP2Internal
 		mapEnergyCannon,          // 49
 
 		mapBlast,                 // 4A EMP/Sticky foam blast
-    mapBFG,                   // 4B Unknown "BFG"
+		mapBFG,                   // 4B Unknown "BFG"
 
 		mapLightning = 0x4C,      // 4C
 		mapVortex,                // 4D

--- a/Game/EnumMapId.h
+++ b/Game/EnumMapId.h
@@ -1,0 +1,151 @@
+#pragma once
+
+
+namespace OP2Internal
+{
+	enum map_id {
+		mapAny = -1,              // FF Use to specify 'all' or 'any'
+		mapNone = 0,              // 00
+
+		mapVehicleFirst = 1,      // 01
+
+		mapCargoTruck = 1,        // 01
+		mapConVec,                // 02
+		mapSpider,                // 03
+		mapScorpion,              // 04
+		mapLynx,                  // 05
+		mapPanther,               // 06
+		mapTiger,                 // 07
+		mapRoboSurveyor,          // 08
+		mapRoboMiner,             // 09
+		mapGeoCon,                // 0A
+		mapScout,                 // 0B
+		mapRoboDozer,             // 0C
+		mapEvacuationTransport,   // 0D
+		mapRepairVehicle,         // 0E
+		mapEarthworker,           // 0F
+		mapSmallCapacityAirTransport, // 10 Crashes game when it moves (looks like a scout)
+
+		mapVehicleLast = 0x10,    // 10
+
+		mapTube,                  // 11
+		mapWall,                  // 12
+		mapLavaWall,              // 13
+		mapMicrobeWall,           // 14
+
+		mapBuildingFirst = 0x15,  // 15
+
+		mapCommonOreMine = 0x15,  // 15
+		mapRareOreMine,           // 16
+		mapGuardPost,             // 17
+		mapLightTower,            // 18
+		mapCommonStorage,         // 19
+		mapRareStorage,           // 1A
+		mapForum,                 // 1B
+		mapCommandCenter,         // 1C
+		mapMHDGenerator,          // 1D
+		mapResidence,             // 1E
+		mapRobotCommand,          // 1F
+		mapTradeCenter,           // 20
+		mapBasicLab,              // 21
+		mapMedicalCenter,         // 22
+		mapNursery,               // 23
+		mapSolarPowerArray,       // 24
+		mapRecreationFacility,    // 25
+		mapUniversity,            // 26
+		mapAgridome,              // 27
+		mapDIRT,                  // 28
+		mapGarage,                // 29
+		mapMagmaWell,             // 2A
+		mapMeteorDefense,         // 2B
+		mapGeothermalPlant,       // 2C
+		mapArachnidFactory,       // 2D
+		mapConsumerFactory,       // 2E
+		mapStructureFactory,      // 2F
+		mapVehicleFactory,        // 30
+		mapStandardLab,           // 31
+		mapAdvancedLab,           // 32
+		mapObservatory,           // 33
+		mapReinforcedResidence,   // 34
+		mapAdvancedResidence,     // 35
+		mapCommonOreSmelter,      // 36
+		mapSpaceport,             // 37
+		mapRareOreSmelter,        // 38
+		mapGORF,                  // 39
+		mapTokamak,               // 3A
+
+		mapBuildingLast = 0x3A,   // 3A
+
+		mapAcidCloud,             // 3B
+		mapEMP,                   // 3C
+		mapLaser,                 // 3D
+		mapMicrowave,             // 3E
+		mapRailGun,               // 3F
+		mapRPG,                   // 40
+		mapStarflare,             // 41 Vehicle Starflare
+		mapSupernova,             // 42 Vehicle Supernova
+		mapStarflare2,            // 43 GuardPost Starflare
+		mapSupernova2,            // 44 GuardPost Supernova
+		mapNormalUnitExplosion,   // 45
+		mapESG,                   // 46
+		mapStickyfoam,            // 47
+		mapThorsHammer,           // 48
+		mapEnergyCannon,          // 49
+
+		mapBlast,                 // 4A EMP/Sticky foam blast
+    mapBFG,                   // 4B Unknown "BFG"
+
+		mapLightning = 0x4C,      // 4C
+		mapVortex,                // 4D
+		mapEarthquake,            // 4E
+		mapEruption,              // 4F
+		mapMeteor,                // 50
+
+		mapMiningBeacon,          // 51
+		mapMagmaVent,             // 52
+		mapFumarole,              // 53
+
+		mapWreckage,              // 54
+
+		mapDisasterousBuildingExplosion,  // 55
+		mapCatastrophicBuildingExplosion, // 56
+		mapAtheistBuildingExplosion,      // 57
+
+		mapEDWARDSatellite,       // 58  Lynx (in Cargo Truck)
+		mapSolarSatellite,        // 59  Wreckage (in Cargo Truck)
+		mapIonDriveModule,        // 5A  Gene Bank 5 (in Cargo Truck)
+		mapFusionDriveModule,     // 5B
+		mapCommandModule,         // 5C
+		mapFuelingSystems,        // 5D
+		mapHabitatRing,           // 5E
+		mapSensorPackage,         // 5F
+		mapSkydock,               // 60
+		mapStasisSystems,         // 61
+		mapOrbitalPackage,        // 62
+		mapPhoenixModule,         // 63
+
+		mapRareMetalsCargo,       // 64
+		mapCommonMetalsCargo,     // 65
+		mapFoodCargo,             // 66
+		mapEvacuationModule,      // 67
+		mapChildrenModule,        // 68
+
+		mapSULV,                  // 69
+		mapRLV,                   // 6A
+		mapEMPMissile,            // 6B
+
+		mapImpulseItems,          // 6C
+		mapWares,                 // 6D
+		mapLuxuryWares,           // 6E
+
+		mapInterColonyShuttle,    // 6F
+		mapSpider3Pack,           // 70
+		mapScorpion3Pack,         // 71
+
+		mapPrettyArt,             // 72 (Used for explosions)
+
+		mapGeneralUnit,           // 73 Don't try to create this unless you're implementing a new unit class
+
+		mapUnitLast = 0x73,       // 73
+	};
+}  // End namespace

--- a/Game/EnumTechCategory.h
+++ b/Game/EnumTechCategory.h
@@ -1,0 +1,23 @@
+#pragma once
+
+
+namespace OP2Internal
+{
+	// "CATEGORY" values (for both items and upgrades to these items)
+	enum TechCategory
+	{
+		tcFree,                 // 0 = Free technologies (and unavailable technologies)
+		tcBasic,                // 1 = Basic labratory sciences
+		tcDefenses,             // 2 = Defenses (GP upgrade, walls, and efficiency engineering)
+		tcPower,                // 3 = Power
+		tcVehicles,             // 4 = Vehicles (which ones can be built, speed upgrades, armor upgrades)
+		tcFood,                 // 5 = Food
+		tcMetals,               // 6 = Metals gathering
+		tcWeapons,              // 7 = Weapons
+		tcSpace,                // 8 = Space (spaceport, observatory, launch vehicle, skydock)
+		tcPopulationHappiness,  // 9 = Population (happiness)
+		tcDisaster,             // 10 = Disaster warning (and defense)
+		tcPopulationGrowth,     // 11 = Population (health, growth)
+		tcSpaceshipModule,      // 12 = Spaceship module
+	};
+}	// End namespace

--- a/Game/Research.h
+++ b/Game/Research.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "EnumTechCategory.h"
+
 
 namespace OP2Internal
 {
@@ -9,7 +11,6 @@ namespace OP2Internal
 	struct TechInfo;
 	struct TechUpgradeInfo;
 	struct UpgradeType;
-	enum TechCategory;
 
 
 	class Research
@@ -69,25 +70,6 @@ namespace OP2Internal
 		TechUpgradeInfo* upgrade;	// 0x3C  Pointer to array of structs containing upgrade info
 		int numDependentTechs;		// 0x40  Number of technologies dependent on this one
 		int* dependentTechNum;		// 0x44  Pointer to array of techNums that depend on this tech
-	};
-
-
-	// "CATEGORY" values (for both items and upgrades to these items)
-	enum TechCategory
-	{
-		tcFree,						// 0 = Free technologies (and unavailable technologies)
-		tcBasic,					// 1 = Basic labratory sciences
-		tcDefenses,					// 2 = Defenses (GP upgrade, walls, and efficiency engineering)
-		tcPower,					// 3 = Power
-		tcVehicles,					// 4 = Vehicles (which ones can be built, speed upgrades, armor upgrades)
-		tcFood,						// 5 = Food
-		tcMetals,					// 6 = Metals gathering
-		tcWeapons,					// 7 = Weapons
-		tcSpace,					// 8 = Space (spaceport, observatory, launch vehicle, skydock)
-		tcPopulationHappiness,		// 9 = Population (happiness)
-		tcDisaster,					// 10 = Disaster warning (and defense)
-		tcPopulationGrowth,			// 11 = Population (health, growth)
-		tcSpaceshipModule,			// 12 = Spaceship module
 	};
 
 

--- a/Game/ScStub/EnumUnitClassification.h
+++ b/Game/ScStub/EnumUnitClassification.h
@@ -1,0 +1,10 @@
+#pragma once
+
+
+namespace OP2Internal
+{
+	// Same as Outpost2DLL's enum UnitClassifactions (note the spelling mistake)
+	enum UnitClassification {
+		// **TODO** Fill in
+	};
+}	// End namespace

--- a/Game/ScStub/ScStubGroup.h
+++ b/Game/ScStub/ScStubGroup.h
@@ -1,15 +1,12 @@
 #pragma once
 
 #include "ScStub.h"
-
-
-enum UnitClassifactions;
-enum map_id;
+#include "EnumUnitClassification.h"
+#include "../EnumMapId.h"
 
 
 namespace OP2Internal
 {
-
 	class Unit;
 
 
@@ -23,7 +20,7 @@ namespace OP2Internal
 		UnitNode* next;						// 0x04
 		Unit* unit;							// 0x08
 		int issueCommandTick;				// 0x0C ** [Set to 0xFFF00000 when adding unit to group, related to gameTick and deleteWhenEmpty]
-		UnitClassifactions classification;	// 0x10
+		UnitClassification classification;	// 0x10
 		// ----
 	};
 

--- a/Game/ScStub/ScStubGroupBuildGroup.h
+++ b/Game/ScStub/ScStubGroupBuildGroup.h
@@ -5,10 +5,8 @@
 
 
 #include "ScStubGroup.h"
+#include "../EnumMapId.h"
 #include "../../PointTypes.h"
-
-
-enum map_id;
 
 
 namespace OP2Internal

--- a/Game/ScStub/ScStubGroupCombatBase.h
+++ b/Game/ScStub/ScStubGroupCombatBase.h
@@ -6,10 +6,8 @@
 
 #include "ScStubGroup.h"
 #include "../Waypoint.h"
+#include "../EnumMapId.h"
 #include "../../PointTypes.h"
-
-
-enum map_id;
 
 
 namespace OP2Internal

--- a/Game/Sheet.h
+++ b/Game/Sheet.h
@@ -1,13 +1,12 @@
 #pragma once
 
-
 // ** Note: This file needs a lot of work
+
+#include "EnumMapId.h"
 
 
 namespace OP2Internal
 {
-
-	enum map_id;
 	class Unit;
 
 
@@ -23,153 +22,6 @@ namespace OP2Internal
 		int b1;					// **
 		int b2;					// **
 		// ----------------
-	};
-
-
-	enum map_id {
-		mapAny = -1,					// FF Use to specify 'all' or 'any'
-		mapNone = 0,					// 00
-
-		mapVehicleFirst = 1,			// 01
-
-		mapCargoTruck = 1,				// 01
-		mapConVec,						// 02
-		mapSpider,						// 03
-		mapScorpion,					// 04
-		mapLynx,						// 05
-		mapPanther,						// 06
-		mapTiger,						// 07
-		mapRoboSurveyor,				// 08
-		mapRoboMiner,					// 09
-		mapGeoCon,						// 0A
-		mapScout,						// 0B
-		mapRoboDozer,					// 0C
-		mapEvacuationTransport,			// 0D
-		mapRepairVehicle,				// 0E
-		mapEarthworker,					// 0F
-		mapSmallCapacityAirTransport,	// 10 Crashes game when it moves (looks like a scout)
-
-		mapVehicleLast = 0x10,			// 10
-
-		mapTube,						// 11
-		mapWall,						// 12
-		mapLavaWall,					// 13
-		mapMicrobeWall,					// 14
-
-		mapBuildingFirst = 0x15,		// 15
-
-		mapCommonOreMine = 0x15,		// 15
-		mapRareOreMine,					// 16
-		mapGuardPost,					// 17
-		mapLightTower,					// 18
-		mapCommonStorage,				// 19
-		mapRareStorage,					// 1A
-		mapForum,						// 1B
-		mapCommandCenter,				// 1C
-		mapMHDGenerator,				// 1D
-		mapResidence,					// 1E
-		mapRobotCommand,				// 1F
-		mapTradeCenter,					// 20
-		mapBasicLab,					// 21
-		mapMedicalCenter,				// 22
-		mapNursery,						// 23
-		mapSolarPowerArray,				// 24
-		mapRecreationFacility,			// 25
-		mapUniversity,					// 26
-		mapAgridome,					// 27
-		mapDIRT,						// 28
-		mapGarage,						// 29
-		mapMagmaWell,					// 2A
-		mapMeteorDefense,				// 2B
-		mapGeothermalPlant,				// 2C
-		mapArachnidFactory,				// 2D
-		mapConsumerFactory,				// 2E
-		mapStructureFactory,			// 2F
-		mapVehicleFactory,				// 30
-		mapStandardLab,					// 31
-		mapAdvancedLab,					// 32
-		mapObservatory,					// 33
-		mapReinforcedResidence,			// 34
-		mapAdvancedResidence,			// 35
-		mapCommonOreSmelter,			// 36
-		mapSpaceport,					// 37
-		mapRareOreSmelter,				// 38
-		mapGORF,						// 39
-		mapTokamak,						// 3A
-
-		mapBuildingLast = 0x3A,			// 3A
-
-		mapAcidCloud,					// 3B
-		mapEMP,							// 3C
-		mapLaser,						// 3D
-		mapMicrowave,					// 3E
-		mapRailGun,						// 3F
-		mapRPG,							// 40
-		mapStarflare,					// 41 Vehicle Starflare
-		mapSupernova,					// 42 Vehicle Supernova
-		mapStarflare2,					// 43 GuardPost Starflare
-		mapSupernova2,					// 44 GuardPost Supernova
-		mapNormalUnitExplosion,			// 45
-		mapESG,							// 46
-		mapStickyfoam,					// 47
-		mapThorsHammer,					// 48
-		mapEnergyCannon,				// 49
-
-		mapBlast,						// 4A EMP/Sticky foam blast
-		//mapUnknown4B,					// 4B Unknown what this is  "BFG"
-
-		mapLightning = 0x4C,			// 4C
-		mapVortex,						// 4D
-		mapEarthquake,					// 4E
-		mapEruption,					// 4F
-		mapMeteor,						// 50
-
-		mapMiningBeacon,				// 51
-		mapMagmaVent,					// 52
-		mapFumarole,					// 53
-
-		mapWreckage,					// 54
-
-		mapDisasterousBuildingExplosion,	// 55
-		mapCatastrophicBuildingExplosion,	// 56
-		mapAtheistBuildingExplosion,		// 57
-
-		mapEDWARDSatellite,				// 58  Lynx (in Cargo Truck)
-		mapSolarSatellite,				// 59  Wreckage (in Cargo Truck)
-		mapIonDriveModule,				// 5A  Gene Bank 5 (in Cargo Truck)
-		mapFusionDriveModule,			// 5B
-		mapCommandModule,				// 5C
-		mapFuelingSystems,				// 5D
-		mapHabitatRing,					// 5E
-		mapSensorPackage,				// 5F
-		mapSkydock,						// 60
-		mapStasisSystems,				// 61
-		mapOrbitalPackage,				// 62
-		mapPhoenixModule,				// 63
-
-		mapRareMetalsCargo,				// 64
-		mapCommonMetalsCargo,			// 65
-		mapFoodCargo,					// 66
-		mapEvacuationModule,			// 67
-		mapChildrenModule,				// 68
-
-		mapSULV,						// 69
-		mapRLV,							// 6A
-		mapEMPMissile,					// 6B
-
-		mapImpulseItems,				// 6C
-		mapWares,						// 6D
-		mapLuxuryWares,					// 6E
-
-		mapInterColonyShuttle,			// 6F
-		mapSpider3Pack,					// 70
-		mapScorpion3Pack,				// 71
-
-		mapPrettyArt,					// 72 (Used for explosions)
-
-		mapGeneralUnit,					// 73 Don't try to create this unless you're implementing a new unit class
-
-		mapUnitLast = 0x73,				// 73
 	};
 
 

--- a/Game/Unit/EnumTruckCargo.h
+++ b/Game/Unit/EnumTruckCargo.h
@@ -1,0 +1,10 @@
+#pragma once
+
+
+namespace OP2Internal
+{
+	// Same as Outpost2DLL's enum Truck_Cargo
+	enum TruckCargo {
+		// **TODO** Fill in
+	};
+}	// End namespace

--- a/Game/Unit/UnitVehicle.h
+++ b/Game/Unit/UnitVehicle.h
@@ -1,7 +1,7 @@
 #pragma once
 
-
 #include "Unit.h"
+#include "EnumTruckCargo.h"
 
 
 namespace OP2Internal
@@ -38,7 +38,7 @@ namespace OP2Internal
 		// ----  [Overridden base class functions]
 		// ... **TODO**
 		// ----  [New virtual functions]
-		virtual void SetCargo(enum Truck_Cargo truckCargo, int cargoAmountOrTechID, short a2);	// 0x94 **
+		virtual void SetCargo(TruckCargo truckCargo, int cargoAmountOrTechID, short a2);	// 0x94 **
 		virtual void F9();							// 0x98 **
 		// ----
 	};

--- a/OP2Internal.vcxproj
+++ b/OP2Internal.vcxproj
@@ -58,9 +58,13 @@
     <ClCompile Include="DummyMain.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <CustomBuild Include="OP2Internal.asm"/>
+    <CustomBuild Include="OP2Internal.asm" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Game\EnumMapId.h" />
+    <ClInclude Include="Game\EnumTechCategory.h" />
+    <ClInclude Include="Game\ScStub\EnumUnitClassification.h" />
+    <ClInclude Include="Game\Unit\EnumTruckCargo.h" />
     <ClInclude Include="OP2Internal.h" />
     <ClInclude Include="Game\CommandPacket.h" />
     <ClInclude Include="Game\EnumActionType.h" />
@@ -112,6 +116,7 @@
     <ClInclude Include="ResourceManagement\BitmapLightAdjustedBitmapMemoryMappedBitmap.h" />
     <ClInclude Include="ResourceManagement\BitmapLightAdjustedBitmapTileSet.h" />
     <ClInclude Include="ResourceManagement\CConfig.h" />
+    <ClInclude Include="ResourceManagement\EnumSongId.h" />
     <ClInclude Include="ResourceManagement\MusicManager.h" />
     <ClInclude Include="ResourceManagement\Palette.h" />
     <ClInclude Include="ResourceManagement\PrtGraphics.h" />
@@ -140,6 +145,9 @@
     <ClInclude Include="UserInterface\CommandPaneView\ReportViews\LabReportView.h" />
     <ClInclude Include="UserInterface\CommandPaneView\Views\BuildingStorageBayView.h" />
     <ClInclude Include="UserInterface\CommandPaneView\Views\UnitView.h" />
+    <ClInclude Include="UserInterface\Filter\EnumBehaviorType.h" />
+    <ClInclude Include="UserInterface\Filter\EnumFilterOption.h" />
+    <ClInclude Include="UserInterface\Filter\EnumFilterPosition.h" />
     <ClInclude Include="UserInterface\Filter\Filter.h" />
     <ClInclude Include="UserInterface\Filter\FilterGroupFilter.h" />
     <ClInclude Include="UserInterface\Filter\FilterGroupFilterDetailPaneFilter.h" />

--- a/OP2Internal.vcxproj.filters
+++ b/OP2Internal.vcxproj.filters
@@ -355,6 +355,30 @@
       <Filter>Game</Filter>
     </ClInclude>
     <ClInclude Include="OP2Internal.h" />
+    <ClInclude Include="Game\EnumMapId.h">
+      <Filter>Game</Filter>
+    </ClInclude>
+    <ClInclude Include="Game\EnumTechCategory.h">
+      <Filter>Game</Filter>
+    </ClInclude>
+    <ClInclude Include="Game\ScStub\EnumUnitClassification.h">
+      <Filter>Game\ScStub</Filter>
+    </ClInclude>
+    <ClInclude Include="Game\Unit\EnumTruckCargo.h">
+      <Filter>Game\Unit</Filter>
+    </ClInclude>
+    <ClInclude Include="ResourceManagement\EnumSongId.h">
+      <Filter>ResourceManagement</Filter>
+    </ClInclude>
+    <ClInclude Include="UserInterface\Filter\EnumBehaviorType.h">
+      <Filter>UserInterface\Filter</Filter>
+    </ClInclude>
+    <ClInclude Include="UserInterface\Filter\EnumFilterOption.h">
+      <Filter>UserInterface\Filter</Filter>
+    </ClInclude>
+    <ClInclude Include="UserInterface\Filter\EnumFilterPosition.h">
+      <Filter>UserInterface\Filter</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Game">

--- a/ResourceManagement/EnumSongId.h
+++ b/ResourceManagement/EnumSongId.h
@@ -1,0 +1,9 @@
+#pragma once
+
+
+namespace OP2Internal
+{
+	enum SongId {
+		// **TODO** Fill in
+	};
+}	// End namespace

--- a/ResourceManagement/MusicManager.h
+++ b/ResourceManagement/MusicManager.h
@@ -3,16 +3,13 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include "EnumSongId.h"
 
 struct DirectSoundBuffer;
 
 
 namespace OP2Internal
 {
-
-	enum SongIds;
-
-
 	class MusicManager
 	{
 	public:
@@ -39,7 +36,7 @@ namespace OP2Internal
 		void StartTimer();					// 0x450CC0 
 		void PlayPauseMusic(int bPlayMusic);// 0x450FB0
 		void SetVolume(int volumeIndex);	// 0x451170
-		void SetMusicPlaylist(int numSongs, int repeatStartIndex, SongIds songs[]);	// 0x4511B0
+		void SetMusicPlaylist(int numSongs, int repeatStartIndex, SongId songs[]);	// 0x4511B0
 
 		// Static functions
 		static void MusicTimerCallback();	// 0x450CF0
@@ -62,7 +59,7 @@ namespace OP2Internal
 		CRITICAL_SECTION criticalSection;		// 0xAC [Controls access to +0xA8]
 		int numPlaylistEntries;					// 0xC4
 		int repeatStartIndex;					// 0xC8
-		SongIds* playlist;						// 0xCC int[]*
+		SongId* playlist;						// 0xCC int[]*
 		int currentPlayingSongIndex;			// 0xD0 [PlayList index]
 		int bHasBegunPlayback;					// 0xD4 [Has Playback begun at the first song yet]
 		int currentSongFileIndex;				// 0xD8 [Clm file index]

--- a/UserInterface/Filter/EnumBehaviorType.h
+++ b/UserInterface/Filter/EnumBehaviorType.h
@@ -1,0 +1,15 @@
+#pragma once
+
+
+namespace OP2Internal
+{
+	enum BehaviorType
+	{
+		BandboxUnitSelect = 0,  // Left-clicking starts drawing a bandbox
+		SetRectRegion = 1,      // Bulldoze or Salvage region
+		SetBuildLocation = 2,   // Highlight area under mouse (tile aligned, multicoloured region)
+		SetDest = 3,            // Left-click to set destination (Attack, Move, etc.) (don't select units)
+		SetLineRegion = 4,      // Build Tube, Wall, Lava Wall, or Microbe Wall
+		MouseDisabled = 5,      // Arrow cursor, clicking is disabled (including Right-click)
+	};
+}	// End namespace

--- a/UserInterface/Filter/EnumFilterOption.h
+++ b/UserInterface/Filter/EnumFilterOption.h
@@ -1,0 +1,10 @@
+#pragma once
+
+
+namespace OP2Internal
+{
+	enum FilterOption {
+		FilterOptMouseMessage = 1,
+		FilterOptKeyboardMessage = 2,
+	};
+}	// End namespace

--- a/UserInterface/Filter/EnumFilterPosition.h
+++ b/UserInterface/Filter/EnumFilterPosition.h
@@ -1,0 +1,10 @@
+#pragma once
+
+
+namespace OP2Internal
+{
+	enum FilterPosition {
+		FilterPosLast = 0,
+		FilterPosFirst = 1,
+	};
+}	// End namespace

--- a/UserInterface/Filter/FilterNode.h
+++ b/UserInterface/Filter/FilterNode.h
@@ -1,22 +1,11 @@
 #pragma once
 
+#include "EnumFilterOption.h"
+
 
 namespace OP2Internal
 {
-
 	class Filter;
-
-	enum FilterPositions
-	{
-		FilterPosLast = 0,
-		FilterPosFirst = 1,
-	};
-
-	enum FilterOptions
-	{
-		FilterOptMouseMessage = 1,
-		FilterOptKeyboardMessage = 2,
-	};
 
 
 	// Size: 0x14  [New, fields accessed]
@@ -26,7 +15,7 @@ namespace OP2Internal
 		FilterNode* next;				// 0x4
 		Filter* filter;					// 0x8
 		int userData;					// 0xC
-		FilterOptions filterOptions;	// 0x10
+		FilterOption filterOption;	// 0x10
 	};
 
 }	// End namespace

--- a/UserInterface/Filter/FilterSubFilterMouseCommandFilter.h
+++ b/UserInterface/Filter/FilterSubFilterMouseCommandFilter.h
@@ -2,15 +2,14 @@
 
 
 #include "FilterSubFilter.h"
+#include "EnumBehaviorType.h"
 #include "../../PointTypes.h"
 
 
 namespace OP2Internal
 {
-
 	class BoolState;
 	class Pane;
-	enum BehaviorType;
 
 
 	class MouseCommandFilter : public SubFilter
@@ -62,18 +61,6 @@ namespace OP2Internal
 		int b7;						// 0x3C **  
 		// ...?
 	};
-
-
-	enum BehaviorType
-	{
-		BandboxUnitSelect = 0,		// Left-clicking starts drawing a bandbox
-		SetRectRegion = 1,			// Bulldoze or Salvage region
-		SetBuildLocation = 2,		// Highlight area under mouse (tile aligned, multicoloured region)
-		SetDest = 3,				// Left-click to set destination (Attack, Move, etc.) (don't select units)
-		SetLineRegion = 4,			// Build Tube, Wall, Lava Wall, or Microbe Wall
-		MouseDisabled = 5,			// Arrow cursor, clicking is disabled (including Right-click)
-	};
-
 
 
 	extern MouseCommandFilter mouseCommandFilter;		// 0x5471B0

--- a/UserInterface/IWnd/IWnd.h
+++ b/UserInterface/IWnd/IWnd.h
@@ -1,6 +1,7 @@
 #pragma once
 
-
+#include "../Filter/EnumFilterPosition.h"
+#include "../Filter/EnumFilterOption.h"
 #include "../../WinTypes.h"
 
 
@@ -28,7 +29,7 @@ namespace OP2Internal
 		IWnd();
 		class IWnd & operator=(class IWnd const &);
 		class FilterNode * FindNode(class Filter *,int);
-		void InstallFilter(class Filter*, int userData, enum FilterPositions, enum FilterOptions);
+		void InstallFilter(class Filter*, int userData, FilterPosition filterPosition, FilterOption filterOptions);
 		void RemoveFilter(class Filter*, int userData);
 
 		// Static functions


### PR DESCRIPTION
Move enum declarations to separate header files, and include them, rather than try to forward declare them.

This is a safer alternative to PR #17. As it avoids switching to enum class, it avoids the possibility of structs with enum fields from changing size due to this update.

We may wish to migrate to `enum class` at a later point in the future. At that time, we can consider switching back to forward declares, rather than including the enum header, though enum headers are usually fairly small anyway.

Note: This change (or #17) is needed to prevent compile errors with Mingw. Forward declaring old style `enum` declarations is not standards compliant.
