### PR TITLE
Add static size checks

### DIFF
--- a/Game/CommandPacket.h
+++ b/Game/CommandPacket.h
@@ -18,6 +18,7 @@ namespace OP2Internal
 		int timeStamp;					// 0x06
 		int unknown;					// 0x0A **
 	};
+	static_assert(14 == sizeof(CommandPacketHeader), "Unexpected struct size");
 	#pragma pack(pop)
 
 
@@ -27,6 +28,7 @@ namespace OP2Internal
 		CommandPacketHeader cpHeader;
 		char data[99];					// 0x0E ** [Need adjustment after pragma pack?]
 	};
+	static_assert(113 == sizeof(CommandPacket), "Unexpected struct size");
 
 
 	namespace CP
@@ -43,17 +45,22 @@ namespace OP2Internal
 			char numUnits;		// If negative, then hot key group?
 			short unitIndex[1];	// List of unit indexes
 		};
+		static_assert(3 == sizeof(UnitList), "Unexpected struct size");  // Note: Variable dynamic size
 
 		struct WaypointList
 		{
 			short numWaypoints;
 			Waypoint waypoint[1];
 		};
+		static_assert(6 == sizeof(WaypointList), "Unexpected struct size");  // Note: Variable dynamic size
+
 		struct ShortPoint
 		{
 			short x;
 			short y;
 		};
+		static_assert(4 == sizeof(ShortPoint), "Unexpected struct size");
+
 		union ShortRect
 		{
 			struct
@@ -71,6 +78,7 @@ namespace OP2Internal
 				ShortPoint bottomRight;
 			};
 		};
+		static_assert(8 == sizeof(ShortRect), "Unexpected struct size");
 
 
 		// Data structs
@@ -85,6 +93,7 @@ namespace OP2Internal
 			short mineUnitIndex;
 			short smelterUnitIndex;
 		};
+		static_assert(8 == sizeof(CargoRoute), "Unexpected struct size");
 
 		struct Patrol
 		{
@@ -93,6 +102,7 @@ namespace OP2Internal
 			short unknown1;		// ** Probably waypoint indexes of end patrol endpoints
 			short unknown2;		// **
 		};
+		static_assert(4 == sizeof(Patrol), "Unexpected struct size");
 
 		struct Build
 		{
@@ -101,6 +111,7 @@ namespace OP2Internal
 			ShortRect buildArea;
 			short unknown;		// ** Might be scStubIndex (related to BuildGroup), set to -1 if not used
 		};
+		static_assert(10 == sizeof(Build), "Unexpected struct size");
 
 		struct BuildWall
 		{
@@ -110,6 +121,7 @@ namespace OP2Internal
 			short tubeWallType;	// enum map_id
 			short unknown;		// ** Might be scStubIndex (related to BuildGroup), set to 0 if not used
 		};
+		static_assert(12 == sizeof(BuildWall), "Unexpected struct size");
 
 		struct RemoveWall
 		{
@@ -117,6 +129,7 @@ namespace OP2Internal
 			//WaypointList
 			ShortRect removeArea;
 		};
+		static_assert(8 == sizeof(RemoveWall), "Unexpected struct size");
 
 		struct Produce
 		{
@@ -133,27 +146,32 @@ namespace OP2Internal
 			short bayIndex;				// 0x10
 			short unknown;				// 0x12 ** Might be scStubIndex, set to 0 if not used
 		};
+		static_assert(6 == sizeof(TransferCargo), "Unexpected struct size");
 
 		struct LoadUnloadCargo
 		{
 			short buildingUnitIndex;
 		};
+		static_assert(2 == sizeof(LoadUnloadCargo), "Unexpected struct size");
 
 		struct Recycle
 		{
 			short unitIndex;
 			short unknown;		// **
 		};
+		static_assert(4 == sizeof(Recycle), "Unexpected struct size");
 
 		struct DumpCargo
 		{
 			short unitIndex;
 		};
+		static_assert(2 == sizeof(DumpCargo), "Unexpected struct size");
 
 		struct Idle
 		{
 			short buildingUnitIndex;
 		};
+		static_assert(2 == sizeof(Idle), "Unexpected struct size");
 
 		struct SelfDestruct
 		{
@@ -171,18 +189,21 @@ namespace OP2Internal
 			short techIndex;
 			short numScientists;
 		};
+		static_assert(6 == sizeof(Research), "Unexpected struct size");
 
 		struct Train
 		{
 			short universityUnitIndex;
 			short numTrain;
 		};
+		static_assert(4 == sizeof(Train), "Unexpected struct size");
 
 		struct Transfer
 		{
 			//UnitList
 			short destPlayerNum;	// Note: *Write short, read char*
 		};
+		static_assert(2 == sizeof(Transfer), "Unexpected struct size");
 
 		struct Launch
 		{
@@ -190,6 +211,7 @@ namespace OP2Internal
 			short destPixelX;
 			short destPixelY;
 		};
+		static_assert(6 == sizeof(Launch), "Unexpected struct size");
 
 		struct Salvage
 		{
@@ -197,6 +219,7 @@ namespace OP2Internal
 			ShortRect salvageArea;
 			short unknown;		// **
 		};
+		static_assert(12 == sizeof(Salvage), "Unexpected struct size");
 
 		struct CreateUnitInfo
 		{
@@ -211,12 +234,14 @@ namespace OP2Internal
 			short numUnits;
 			CreateUnitInfo createUnitInfo[1];	// **
 		};
+		static_assert(14 == sizeof(Create), "Unexpected struct size");   // Note: Variable dynamic size
 
 		struct SetLights
 		{
 			//UnitList
 			short newState;		// 0 = off, 1 = on
 		};
+		static_assert(2 == sizeof(SetLights), "Unexpected struct size");
 
 		struct Attack
 		{
@@ -231,11 +256,13 @@ namespace OP2Internal
 				};
 			};
 		};
+		static_assert(6 == sizeof(Attack), "Unexpected struct size");
 
 		struct Poof
 		{
 			short unitIndex;
 		};
+		static_assert(2 == sizeof(Poof), "Unexpected struct size");
 
 		// Variables not defined here are assumed to be dword indexes into TethysGame object
 		enum GameOptVariable
@@ -278,6 +305,7 @@ namespace OP2Internal
 			// ---- Only used by specific variables
 			short playerIndex;
 		};
+		static_assert(8 == sizeof(GameOpt), "Unexpected struct size");
 
 		struct Chat
 		{
@@ -285,6 +313,7 @@ namespace OP2Internal
 			char destPlayerBitMask;
 			char message[1];
 		};
+		static_assert(3 == sizeof(Chat), "Unexpected struct size");  // Note: Variable dynamic size
 
 		enum QuitMethod
 		{
@@ -297,12 +326,14 @@ namespace OP2Internal
 			char quitMethod;
 			char lParam;
 		};
+		static_assert(2 == sizeof(Quit), "Unexpected struct size");
 
 		struct Ally
 		{
 			short fromPlayerIndex;	// Note: *Never read*
 			short toPlayerIndex;	// Note: *Write short, read char*
 		};
+		static_assert(4 == sizeof(Ally), "Unexpected struct size");
 
 		struct GoAI
 		{
@@ -316,6 +347,7 @@ namespace OP2Internal
 			short windowWidth;				// Dans_RULE_UIFrame
 			short windowHeight;				// Dans_RULE_UIFrame
 		};
+		static_assert(8 == sizeof(MachineSettings), "Unexpected struct size");
 	}
 
 	#pragma pack(pop)

--- a/Game/CommandPacket.h
+++ b/Game/CommandPacket.h
@@ -125,6 +125,7 @@ namespace OP2Internal
 			short weaponType;			// 0x12 enum map_id
 			short scStubIndex;			// 0x14 -1 if not used
 		};
+		static_assert(8 == sizeof(Produce), "Unexpected struct size");
 
 		struct TransferCargo
 		{
@@ -204,6 +205,7 @@ namespace OP2Internal
 			short tileY;
 			int weaponOrCargo;	// enum map_id
 		};
+		static_assert(12 == sizeof(CreateUnitInfo), "Unexpected struct size");
 		struct Create
 		{
 			short numUnits;

--- a/Game/GameOpt.h
+++ b/Game/GameOpt.h
@@ -1,6 +1,7 @@
 #pragma once
 
 
+
 namespace OP2Internal
 {
 
@@ -117,5 +118,6 @@ namespace OP2Internal
 		};
 		int option[numOptions];				// 26 Options
 	};
+	static_assert(104 == sizeof(GameOpt), "Unexpected struct size");
 
 }	// End namespace

--- a/Game/Player.h
+++ b/Game/Player.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include "CommandPacket.h"
 #include "UnitGroup.h"
 #include "GameStartInfo/MoraleStartInfo.h"
@@ -20,6 +19,7 @@ namespace OP2Internal
 		int numDisabled;
 		int numIdle;
 	};
+	static_assert(16 == sizeof(BuildingStats), "Unexpected struct size");
 
 
 	// Size: 0xC24 = 3108
@@ -134,6 +134,7 @@ namespace OP2Internal
 		Unit* unknownUnitList;				// 0xC20 **
 		// ----
 	};
+	static_assert(3108 == sizeof(Player), "Unexpected struct size");
 
 
 	// Globals

--- a/Game/RandomNumberGenerator.h
+++ b/Game/RandomNumberGenerator.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include "../WinTypes.h"
 
 
@@ -22,6 +21,7 @@ namespace OP2Internal
 		unsigned int dword1;	// 0x0
 		unsigned int dword2;	// 0x4
 	};
+	static_assert(8 == sizeof(RandomNumberGenerator), "Unexpected struct size");
 
 
 	// Globals

--- a/Game/ScStub/ScStubGroupCombatBase.h
+++ b/Game/ScStub/ScStubGroupCombatBase.h
@@ -47,5 +47,6 @@ namespace OP2Internal
 		int a3Index;					// 0x3E4 ** (Index into a list of objects with 5 function pointers each)
 		// ----
 	};
+	static_assert(0x3E8 == sizeof(CombatBase), "Unexpected struct size");
 
 }	// End namespace

--- a/Game/Sheet.h
+++ b/Game/Sheet.h
@@ -23,6 +23,7 @@ namespace OP2Internal
 		int b2;					// **
 		// ----------------
 	};
+	static_assert(8 == sizeof(Sheet), "Unexpected struct size");
 
 
 	// Globals

--- a/Game/Unit/Unit.h
+++ b/Game/Unit/Unit.h
@@ -1,6 +1,7 @@
 #pragma once
 
 
+
 namespace OP2Internal
 {
 
@@ -41,6 +42,7 @@ namespace OP2Internal
 		unsigned int _30:1;							// 0x1E 0x40000000 **
 		unsigned int _31:1;							// 0x1F 0x80000000 **
 	};
+	static_assert(4 == sizeof(UnitFlags), "Unexpected struct size");
 
 	// Size: 0x54
 	class Unit
@@ -112,6 +114,7 @@ namespace OP2Internal
 		int b5[3];						// 0x48 **
 		// ----
 	};
+	static_assert(0x54 == sizeof(Unit), "Unexpected struct size");
 
 
 
@@ -132,6 +135,7 @@ namespace OP2Internal
 		// ----
 		// ...
 	};
+	// static_assert( == sizeof(PlayerUnit), "Unexpected struct size");
 
 
 	// ** Note ** : There seems to be a missing class between PlayerUnit and Building or Vehicle,

--- a/Game/UnitGroup.h
+++ b/Game/UnitGroup.h
@@ -1,6 +1,7 @@
 #pragma once
 
 
+
 namespace OP2Internal
 {
 
@@ -16,6 +17,7 @@ namespace OP2Internal
 		int numUnits;
 		int unitIndex[32];
 	};
+	static_assert(132 == sizeof(UnitGroup), "Unexpected struct size");
 
 
 	#pragma pack(push, 1)
@@ -24,6 +26,7 @@ namespace OP2Internal
 		char numUnits;
 		short unitIndex[32];
 	};
+	static_assert(65 == sizeof(PackedUnitGroup), "Unexpected struct size");
 	#pragma pack(pop)
 
 

--- a/Game/Waypoint.h
+++ b/Game/Waypoint.h
@@ -1,6 +1,7 @@
 #pragma once
 
 
+
 namespace OP2Internal
 {
 	struct Waypoint
@@ -8,4 +9,5 @@ namespace OP2Internal
 		unsigned int pixelX:15;
 		unsigned int pixelY:14;
 	};
+	static_assert(4 == sizeof(Waypoint), "Unexpected struct size");
 }	// End namespace


### PR DESCRIPTION
Updated branch with more static size checks added.

I would like some feedback on using static size checks for structs with variable sized data. There are two types. Ones that end in an array of 1 element which is actually a variable sized unchecked array, and structs which contain header comments about variable sized fields preceding the struct data.

Example variable sized array:
```cpp
struct UnitList
{
	char numUnits;		// If negative, then hot key group?
	short unitIndex[1];	// List of unit indexes
};
```

Here, depending on the value of `numUnits`, the array might be accessed as:
```cpp
for (int i = 0; i < unitList.numUnits; ++i) {
  DoSomethingWith(unitList.unitIndex[i]); // Extend past static bound of array. Struct is overlaid upon larger buffer
}
```

Example of header comments:
```cpp
struct Patrol
{
	//UnitList
	//WaypointList
	short unknown1;		// ** Probably waypoint indexes of end patrol endpoints
	short unknown2;		// **
};
```

Here the data in the struct is preceded by the variable sized structs listed above. As there is no way for the compiler to calculate their size at compile time, the exact size of the entire construct is also not known at compile time. Indeed, it is a runtime variable size.

Should either of these two types of structs have static size checks? The size checks would only include the single array element, or known fixed fields.

I've included a few such checks in this branch, though it's questionable if they have much value.

----

Edit: Tagging Issue #19.
