### PR TITLE
Change `Packet` from class to struct

### DIFF
--- a/Network/Packet.h
+++ b/Network/Packet.h
@@ -221,10 +221,8 @@ namespace OP2Internal
 	// Packet
 	// ------
 
-	class Packet
+	struct Packet
 	{
-	public:
-		// Member variables
 		PacketHeader header;
 		union
 		{
@@ -233,7 +231,6 @@ namespace OP2Internal
 			GameMessage gameMessage;
 		};
 
-	public:
 		// Member functions
 		int Checksum();
 	};

--- a/Network/Packet.h
+++ b/Network/Packet.h
@@ -232,7 +232,7 @@ namespace OP2Internal
 		};
 
 		// Member functions
-		int Checksum();
+		int Checksum() const;
 	};
 
 


### PR DESCRIPTION
It allows public access to all fields. It is primarily a struct, rather than a class.

This may require changes in client libraries if they refer to `Packet` explicitly as a class, such as in forward declarations.
