### PR TITLE
Fix Integration Issues Noticed in NetFixClient

### DIFF
--- a/Network/NetTransportLayer.h
+++ b/Network/NetTransportLayer.h
@@ -5,7 +5,7 @@
 namespace OP2Internal
 {
 
-	class Packet;
+	struct Packet;
 
 
 	struct TrafficCounters

--- a/Network/Packet.h
+++ b/Network/Packet.h
@@ -232,7 +232,7 @@ namespace OP2Internal
 		};
 
 		// Member functions
-		int Checksum() const;
+		int Checksum();
 	};
 
 

--- a/Network/Packet.h
+++ b/Network/Packet.h
@@ -232,7 +232,7 @@ namespace OP2Internal
 		};
 
 		// Member functions
-		int Checksum();
+		int Checksum() const;
 	};
 
 

--- a/OP2Internal.asm
+++ b/OP2Internal.asm
@@ -489,7 +489,7 @@ Export 0x004C1380, ??3GurManager@OP2Internal@@SAXPAX@Z		; operator Delete
 ; Packet
 ; ------
 ; Member functions
-Export 0x00490F10, ?Checksum@Packet@OP2Internal@@QAEHXZ
+Export 0x00490F10, ?Checksum@Packet@OP2Internal@@QBEHXZ
 
 
 


### PR DESCRIPTION
Apparently marking Checksum as const is not binary compatible. Also missed changing a forward declare.