### PR TITLE
Add scoped PeerStatus enum

### DIFF
--- a/src/Network/Packet.h
+++ b/src/Network/Packet.h
@@ -53,6 +53,15 @@ namespace OP2Internal
 		tlcEchoExternalAddress = 12,
 	};
 
+	enum class PeerStatus : short
+	{
+		EmptySlot,
+		Joining, // Joining Player Cleaned from list
+		Normal,
+		ReplicateSuccess, // Successfully replicated players list
+		ReplicateFailure  // Failed to replicate players list
+	};
+
 
 	// ****************************************
 
@@ -65,7 +74,7 @@ namespace OP2Internal
 	{
 		int ip;
 		short port;
-		short status;
+		PeerStatus status;
 		int playerNetID;
 	};
 
@@ -103,7 +112,7 @@ namespace OP2Internal
 
 	struct StatusUpdate : public TransportLayerHeader
 	{
-		short newStatus;
+		PeerStatus newStatus;
 	};
 
 


### PR DESCRIPTION
I have this compiled and running with a modified NetFixClient on my machine. It seems to run fine with Outpost 2. I wasn't sure if changing the type to scoped enum in the two structs would be harmful or not.